### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ethernaut Reforged 👩‍🚀🔨
 
-This repo is a customized Foundry environment where devs can create/solve/submit ethernaut challenges without the need for interaction with the [Ethernaut CTF webiste](https://ethernaut.openzeppelin.com/). 
+This repo is a customized Foundry environment where devs can create/solve/submit ethernaut challenges without the need for interaction with the [Ethernaut CTF website](https://ethernaut.openzeppelin.com/). 
 
 ## Setup
 
@@ -24,4 +24,4 @@ This will run a local simulation of your transaction off chain, if your script p
 
 ## Further Updates
 
-This repo is still a work in progress, and eventually all 29 of the Ethernaut challenges will be added. The description and hints from the ethernaut site for each challenge will be bought over as well as adding some extra resources based on the specific vulnerability the challenge highlights including educational content and real world examples.
+This repo is still a work in progress, and eventually all 29 of the Ethernaut challenges will be added. The description and hints from the ethernaut site for each challenge will be brought over as well as adding some extra resources based on the specific vulnerability the challenge highlights including educational content and real world examples.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo is a customized Foundry environment where devs can create/solve/submit
 - Clone this repo
 - Copy the items in `.env.example` with your own credentials
 - Open `/script/setup/EthernautHelper.sol` and edit the `HERO` variable to your own address
-- Get some testnet eth (Sepolia is recommended as ether is easier to comeby)
+- Get some testnet eth (Sepolia is recommended as ether is easier to come by)
 
 ## Completing A Challenge
 


### PR DESCRIPTION
This commit fixes a minor typographical error in the README file. The word "comeby" was incorrectly written as a single word instead of the correct form "come by" with a space between the words.

Changes Made:

Updated the occurrence of "comeby" to "come by" in the README file.

Impact:
By correcting this typo, we ensure consistency and accuracy in the codebase, improving readability and reducing potential confusion for developers and users who come across this code in the future.

Note:
This change does not affect the functionality or behavior of the code, but it enhances the overall quality and professionalism of the project.